### PR TITLE
safeguard against duplicate on/using calls

### DIFF
--- a/es6-traits.js
+++ b/es6-traits.js
@@ -31,12 +31,30 @@ export default function({
     }
   });
 
+  let onCalled = false;
+  let usingCalled = false;
+  const throwDuplicateCallError = (name) => {
+    throw new RangeError(`traits().${name} may only be called once.  Create a new on/using pair for each class`);
+  };
+
   return {
     on(baseclass) {
+      if (onCalled) {
+        throwDuplicateCallError('on');
+      } else {
+        onCalled = true;
+      }
+
       BaseClass = baseclass;
     },
 
     using(...traits) {
+      if (usingCalled) {
+        throwDuplicateCallError('using');
+      } else {
+        usingCalled = true;
+      }
+
       const traitsClassName = `${BaseClass.name}_with_${traits.map(x => x.toString().slice(8, -1)).join('_and_').replace(' ', '_')}`;
 
       if (cache[traitsClassName]) {


### PR DESCRIPTION
My understanding is that calling on/using more than once will cause the second call to influence new instances of the first class it's used on.

This is just a check to identify programmer error.
